### PR TITLE
fix(delete): require exact 'yes' confirmation

### DIFF
--- a/lua/dired/dired.lua
+++ b/lua/dired/dired.lua
@@ -264,9 +264,8 @@ function M.delete_file_range()
         table.insert(files, filename)
         print(string.format('   {%.2d: "%s"}', _, filename))
     end
-    local prompt = vim.fn.input("Confirm deletion {yes,n(o),q(uit)}: ", "yes", "file")
-    prompt = string.lower(prompt)
-    if string.sub(prompt, 1, 3) == "yes" then
+    local prompt = vim.fn.input("Confirm deletion {yes,n(o),q(uit)}: ", "")
+    if prompt == "yes" then
         for _, filename in ipairs(files) do
             local dir_files = ls.fs_entry.get_directory(dir)
             local file = ls.get_file_by_filename(dir_files, filename)
@@ -360,9 +359,8 @@ function M.delete_marked()
     if files_out_of_cwd then
         print("[!] WARNING: You have files marked that are outside of your current working directory.")
     end
-    local prompt = vim.fn.input("Confirm deletion {yes,n(o),q(uit)}: ", "yes", "file")
-    prompt = string.lower(prompt)
-    if string.sub(prompt, 1, 3) == "yes" then
+    local prompt = vim.fn.input("Confirm deletion {yes,n(o),q(uit)}: ", "")
+    if prompt == "yes" then
         for _, fs_t in ipairs(marked_files) do
             display.cursor_pos = vim.api.nvim_win_get_cursor(0)
             display.goto_filename = ""

--- a/lua/dired/functions.lua
+++ b/lua/dired/functions.lua
@@ -73,11 +73,9 @@ function M.delete_file(fs_t, ask)
     end
     local prompt = vim.fn.input(
         string.format("Confirm deletion of (%s) {yes,n(o),q(uit)}: ", fs_t.filename),
-        "yes",
-        "file"
+        ""
     )
-    prompt = string.lower(prompt)
-    if string.sub(prompt, 1, 3) == "yes" then
+    if prompt == "yes" then
         if fs_t.filetype == "directory" then
             fs.do_delete(fs_t.filepath)
         else


### PR DESCRIPTION
Fixes unsafe delete confirmations by requiring exact, case-sensitive 'yes' and removing default values for single, range, and marked deletions. References #22.