### PR TITLE
fix(filetype): preserve symlink type from scanner

### DIFF
--- a/lua/dired/filetype.lua
+++ b/lua/dired/filetype.lua
@@ -357,7 +357,8 @@ function M.get_filetype(filename, filetype)
             return "text"
         end
     else
-        return "directory"
+        -- Preserve non-file types reported by the scanner (e.g., "directory", "link", ...)
+        return filetype
     end
 end
 


### PR DESCRIPTION
Preserve non-file types from scanner (e.g., link) instead of coercing to directory. Fixes symlink misclassification.\n\nRefs X3eRo0/dired.nvim#26